### PR TITLE
Enable Freetype support in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,10 @@ RUN apt-get update && apt-get install -y \
     libxml2-dev \
     libpng-dev \
     libjpeg-dev \
+    libfreetype6-dev \
     supervisor \
     default-mysql-client \
-    && docker-php-ext-configure gd --with-jpeg \
+    && docker-php-ext-configure gd --with-jpeg --with-freetype \
     && docker-php-ext-install pdo_mysql mbstring zip xml bcmath pcntl exif gd opcache \
     && pecl install redis \
     && docker-php-ext-enable redis \


### PR DESCRIPTION
## Summary
- add libfreetype6-dev and configure GD with Freetype

## Testing
- `docker build .` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689ed3913e388327a1d8ec157d8bb30d