### PR TITLE
Use single-word login step in Docker workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v3
 
-    - name: Log in to GitHub Container Registry
+    - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
         registry: ghcr.io


### PR DESCRIPTION
## Summary
- Use single-word imperative style for registry authentication step in Docker build workflow

## Testing
- `yamllint .github/workflows/docker-build.yml` *(fails: yamllint not installed; installation blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_689ed4fc3f4483278579657e18a9e13a