### PR TITLE
docs: explain www-data runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-enable redis \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Run the application as www-data for security
 USER www-data
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- document that the application runs as the `www-data` user for security in the Dockerfile

## Testing
- `docker build -t service-test .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_689ed544d22c832791bb79c39f8dcb94