### PR TITLE
Verify redis extension in workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,5 +27,9 @@ jobs:
     - name: Build Docker image
       run: docker build -t ghcr.io/emilmoe/service:latest .
 
+    - name: Verify redis extension
+      run: |
+        docker run --rm ghcr.io/emilmoe/service:latest php -m | grep -q redis
+
     - name: Push Docker image
       run: docker push ghcr.io/emilmoe/service:latest


### PR DESCRIPTION
## Summary
- run built docker image to verify redis extension is installed before pushing

## Testing
- `yamllint .github/workflows/docker-build.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ed58a26fc8327bb0393a1d48eb629