### PR TITLE
Use non-interactive Redis install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
     default-mysql-client \
     && docker-php-ext-configure gd --with-jpeg --with-freetype \
     && docker-php-ext-install pdo_mysql mbstring zip xml bcmath pcntl exif gd opcache \
-    && pecl install redis \
+    && printf "\\n" | pecl install -o -f redis \
     && docker-php-ext-enable redis \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- install Redis extension for PHP non-interactively using `printf "\n" | pecl install -o -f redis`

## Testing
- `docker build -t service:test .` *(fails: command not found: docker)*
- `apt-get install -y docker.io` *(fails: Unable to locate package docker.io)*

------
https://chatgpt.com/codex/tasks/task_e_689ed69f87b48327b9d55ad369e04907