### PR TITLE
chore: upgrade to PHP 8.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-cli
+FROM php:8.4-cli
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository is a foundation for building and publishing a PHP-based Docker i
 ## Key Components
 
 - **Dockerfile**
-  Defines a PHP 8.3 CLI image. Installs common extensions (e.g., pdo_mysql, mbstring, gd, redis) and tools (git, curl, supervisor, MySQL client). Sets the final user to `www-data` and the working directory to `/app`.
+  Defines a PHP 8.4 CLI image. Installs common extensions (e.g., pdo_mysql, mbstring, gd, redis) and tools (git, curl, supervisor, MySQL client). Sets the final user to `www-data` and the working directory to `/app`.
 - **GitHub Actions workflow**
   On every push to `main`, checks out the repo, logs in to GitHub Container Registry, builds the Docker image tagged `ghcr.io/emilmoe/service:latest`, and pushes it to the registry.
 


### PR DESCRIPTION
## Summary
- use php:8.4-cli as the base image
- update docs to reference PHP 8.4

## Testing
- `php -v`
- `docker build -t testimage .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ed80f24948327849d24110dc2b652