### PR TITLE
chore: add basic .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Ignore version control and CI files
+.git
+.github
+
+# Ignore documentation
+README.md
+
+# Ignore Dockerfile itself
+Dockerfile
+
+# TODO: Add application-specific ignores once source code exists


### PR DESCRIPTION
## Summary
- ignore VCS, docs, and Dockerfile in Docker builds
- leave placeholder for future app-specific exclusions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689eddf3c1508327b537a0512e597f1c