### PR TITLE
chore(ci): verify redis extension

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,5 +13,8 @@ jobs:
       - name: Build Docker image
         run: docker build -t service:test .
 
+      - name: Verify redis extension
+        run: docker run --rm service:test php -m | grep -q redis
+
       - name: Verify runtime
         run: docker run --rm service:test php -v


### PR DESCRIPTION
## Summary
- ensure Redis extension is present in PR check workflow

## Testing
- ⚠️ `yamllint .github/workflows/pr-check.yml` *(command not found; pip/apt install failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ede5359f48327957f9fdb85917bb2