### PR TITLE
chore: use GITHUB_TOKEN for Docker registry

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,8 +21,8 @@ jobs:
       uses: docker/login-action@v2
       with:
         registry: ghcr.io
-        username: EmilMoe
-        password: ${{ secrets.PAT_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build Docker image
       run: docker build -t ghcr.io/emilmoe/service:latest .


### PR DESCRIPTION
## Summary
- replace PAT credentials with `github.actor` and `GITHUB_TOKEN`

## Testing
- `docker build -t test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ede5c55208327aea240384c53afc8