### PR TITLE
Configure Dependabot for Docker and pin base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-cli
+FROM php:8.4.0-cli
 
 USER root
 


### PR DESCRIPTION
## Summary
- Add Dependabot config for Docker base image updates
- Pin Docker base image to a specific PHP version

## Testing
- `docker pull php:8.4-cli` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ede7795e4832794a1d7236c06c69e